### PR TITLE
Pin rust-lightning dependency to specific revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/bin/main.rs"
 bitcoin = { version = "0.14", features = ["bitcoinconsensus"] }
 bitcoin-chain = "0.2.1"
 hammersbald = { version="1.0.1", features = ["bitcoin_support"] }
-lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", branch = "master" }
+lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "3c44d6beca2d5c3c50a8454d072ef54f735d5000" }
 mio = "0.6"
 rand = "0.5"
 siphasher = "0.2"


### PR DESCRIPTION
This is the last commit before they updated to rust-bitcoin 0.15, which conflicts with rust-bitcoin 0.14.2 used in this project.

With this change, I was able to build the SPV client.

I also noticed that `Cargo.lock` is not included in the repository (it's ignored). Have you chosen to do that on purpose? A lock file could have prevented the errors I was getting in this case.