### PR TITLE
WIP: fix chaindb shutdown

### DIFF
--- a/src/chaindb.rs
+++ b/src/chaindb.rs
@@ -177,6 +177,12 @@ impl ChainDB {
     pub fn fetch_header(&self, id: &sha256d::Hash) -> Result<Option<StoredHeader>, Error> {
         Ok(self.db.get_hash_keyed::<StoredHeader>(id)?.map(|(_, header)| header))
     }
+
+    /// Shutdown db
+    pub fn shutdown(&mut self) {
+        self.db.shutdown();
+        debug!("shutdown chain db")
+    }
 }
 
 /// A header enriched with information about its position on the blockchain


### PR DESCRIPTION
While testing my example android app (bdk-android-app) I've been getting a corrupt hammersbald db after closing and reopening the app. I added this function to allow my app to gracefully shutdown the db. Doing this shutdown has fixed the issue.  

I'm open to other approaches if anyone has any suggestions. Once I have some feedback on exposing this for manual shutdown or doing something else I'll try to add some tests but so far I haven't been able to reproduce the issue except on an actual phone. 