### PR TITLE
Add travis CI build check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: rust
+rust:
+  - nightly
+  - beta
+  - stable
+cache: cargo


### PR DESCRIPTION
This PR adds a rudimentary [CI check](https://travis-ci.com/github/sgeisler/murmel) to see if PRs compile or change the minimum rust version (which seems to be 1.36.0).