### PR TITLE
Respond to ping to prevent timeout

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -65,6 +65,9 @@ impl Ping {
                                     self.timeout.lock().unwrap().received(pid, 1, ExpectedReply::Pong);
                                 }
                             }
+                            NetworkMessage::Ping(nonce) => {
+                                self.p2p.send_network(pid, NetworkMessage::Pong(nonce));
+                            }
                             _ => { }
                         }
                     }


### PR DESCRIPTION
Currently, bitcoin core nodes disconnect from us after 20 minutes because we don't respond to pings