### PR TITLE
P2P: Update DNS seeds

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -26,24 +26,27 @@ use bitcoin::network::constants::Network;
 use log::{info, trace};
 use std::net::{SocketAddr, ToSocketAddrs};
 
-const MAIN_SEEDER: [&str;5] = [
+const MAIN_SEEDER: [&str; 9] = [
     "seed.bitcoin.sipa.be",
     "dnsseed.bluematt.me",
     "dnsseed.bitcoin.dashjr.org",
     "seed.bitcoinstats.com",
-    "seed.btc.petertodd.org"
+    "seed.bitcoin.jonasschnelli.ch",
+    "seed.btc.petertodd.org",
+    "seed.bitcoin.sprovoost.nl",
+    "dnsseed.emzy.de",
+    "seed.bitcoin.wiz.biz",
 ];
 
-const TEST_SEEDER: [&str;4] = [
+const TEST_SEEDER: [&str; 4] = [
     "testnet-seed.bitcoin.jonasschnelli.ch",
     "seed.tbtc.petertodd.org",
     "seed.testnet.bitcoin.sprovoost.nl",
-    "testnet-seed.bluematt.me"
+    "testnet-seed.bluematt.me",
 ];
 
-
-pub fn dns_seed (network: Network) -> Vec<SocketAddr> {
-    let mut seeds = Vec::new ();
+pub fn dns_seed(network: Network) -> Vec<SocketAddr> {
+    let mut seeds = Vec::new();
     if network == Network::Bitcoin {
         info!("reaching out for DNS seed...");
         for seedhost in MAIN_SEEDER.iter() {


### PR DESCRIPTION
This update brings the DNS seeds into line with Bitcoin Core master
branch at current commit ce3bdd0

https://github.com/bitcoin/bitcoin/blob/ce3bdd0ed1bbfeaa19a5b75dc07943118826f930/src/chainparams.cpp#L116

File formatted with rustfmt.